### PR TITLE
Community Post command rework

### DIFF
--- a/src/modules/discord/client/discord-client.service.ts
+++ b/src/modules/discord/client/discord-client.service.ts
@@ -30,6 +30,7 @@ import { InjectCommands } from "./commands/slash-commands.provider";
 import { EventEmitter2, OnEvent } from "@nestjs/event-emitter";
 import { ChannelQuery } from "../../../modules/platforms/queries";
 import { ChannelEntity } from "../../../modules/platforms/models/channel.entity";
+import { FetchPostCommand } from "../../youtube/community-posts/commands/fetch-post.command";
 
 @Injectable()
 export class DiscordClientService extends Client {
@@ -220,9 +221,9 @@ export class DiscordClientService extends Client {
         const embeds: EmbedBuilder[] = [];
         for (const id of ids) {
             const { posts, channel } = await this.commandBus.execute<
-                FetchPostsCommand,
+                FetchPostCommand,
                 { posts: CommunityPost[]; channel: ChannelInfo }
-            >(new FetchPostsCommand({ postId: id, includeChannelInfo: true }));
+            >(new FetchPostCommand({ includeChannel: true, postId: id }));
             const embed = DiscordUtil.postToEmbed(posts[0], channel);
 
             this.logger.debug(`Generated embed for ${id}.`);

--- a/src/modules/discord/client/discord-client.service.ts
+++ b/src/modules/discord/client/discord-client.service.ts
@@ -16,7 +16,6 @@ import { GuildSettings } from "../models/settings.entity";
 import { getCommandMetadata, SlashCommand } from "./commands/slash-command";
 import { getEvents, handleEvent, On } from "./on-event";
 import { CommandBus, QueryBus } from "@nestjs/cqrs";
-import { FetchPostsCommand } from "../../youtube";
 import { ChannelInfo, CommunityPost } from "yt-scraping-utilities";
 import { DiscordUtil } from "../util";
 import { handleAutocomplete } from "./commands/autocomplete";
@@ -220,11 +219,11 @@ export class DiscordClientService extends Client {
 
         const embeds: EmbedBuilder[] = [];
         for (const id of ids) {
-            const { posts, channel } = await this.commandBus.execute<
+            const { post, channel } = await this.commandBus.execute<
                 FetchPostCommand,
-                { posts: CommunityPost[]; channel: ChannelInfo }
+                { post: CommunityPost; channel: ChannelInfo }
             >(new FetchPostCommand({ includeChannel: true, postId: id }));
-            const embed = DiscordUtil.postToEmbed(posts[0], channel);
+            const embed = DiscordUtil.postToEmbed(post, channel);
 
             this.logger.debug(`Generated embed for ${id}.`);
             embeds.push(embed);

--- a/src/modules/youtube/commands/full-channel-crawl.handler.ts
+++ b/src/modules/youtube/commands/full-channel-crawl.handler.ts
@@ -38,7 +38,8 @@ export class FullChannelCrawlHandler
             source: videoPage,
         });
 
-        const videos: VideoRenderer[] = extractGridVideoRenderers(ytInitialData);
+        const videos: VideoRenderer[] =
+            extractGridVideoRenderers(ytInitialData);
 
         const { visitorData } =
             ytInitialData.responseContext.webResponseContextExtensionData

--- a/src/modules/youtube/community-posts/commands/fetch-post.command.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.command.ts
@@ -3,10 +3,19 @@ import { Util } from "../../../../util";
 
 export interface FetchPostCommandOptions {
     postId: string;
+    /**
+     * Whether to refetch this post even if it's in cache.
+     */
     forceRefetch?: boolean;
+    /**
+     * Whether to include ChannelInfo in the result. Changes return type to `{posts: CommunityPost, channel: ChannelInfo}`.
+     */
     includeChannel?: boolean;
 }
 
+/***
+ * Fetches a single post by ID.
+ */
 export class FetchPostCommand implements ICommand, FetchPostCommandOptions {
     public readonly postId: string;
     public readonly forceRefetch: boolean = false;

--- a/src/modules/youtube/community-posts/commands/fetch-post.command.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.command.ts
@@ -1,0 +1,20 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export interface FetchPostCommandOptions {
+    postId: string;
+    forceRefetch?: boolean;
+}
+
+const DEFAULT_OPTIONS: Omit<FetchPostCommandOptions, "postId"> = {
+    forceRefetch: false,
+}
+
+export class FetchPostCommand implements ICommand, FetchPostCommandOptions {
+    public readonly postId: string;
+    public readonly forceRefetch: boolean;
+    
+    constructor(options: FetchPostCommandOptions) {
+        if (typeof options.postId !== "string") throw new TypeError(`Expected options.postId to be of type string, received ${typeof options.postId}.`);
+        Object.assign(this, {...DEFAULT_OPTIONS, ...options});
+    }
+}

--- a/src/modules/youtube/community-posts/commands/fetch-post.command.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.command.ts
@@ -1,20 +1,22 @@
 import { ICommand } from "@nestjs/cqrs";
+import { Util } from "../../../../util";
 
 export interface FetchPostCommandOptions {
     postId: string;
     forceRefetch?: boolean;
-}
-
-const DEFAULT_OPTIONS: Omit<FetchPostCommandOptions, "postId"> = {
-    forceRefetch: false,
+    includeChannel?: boolean;
 }
 
 export class FetchPostCommand implements ICommand, FetchPostCommandOptions {
     public readonly postId: string;
-    public readonly forceRefetch: boolean;
-    
+    public readonly forceRefetch: boolean = false;
+    public readonly includeChannel?: boolean = false;
+
     constructor(options: FetchPostCommandOptions) {
-        if (typeof options.postId !== "string") throw new TypeError(`Expected options.postId to be of type string, received ${typeof options.postId}.`);
-        Object.assign(this, {...DEFAULT_OPTIONS, ...options});
+        if (typeof options.postId !== "string")
+            throw new TypeError(
+                `Expected options.postId to be of type string, received ${typeof options.postId}.`,
+            );
+        Util.assignIfDefined(this, options);
     }
 }

--- a/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
@@ -1,21 +1,34 @@
 import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { CommunityPost } from "yt-scraping-utilities";
 import { CacheCollection } from "../../../../shared/util/cache-collection";
 import { YouTubeCommunityPostsRequestService } from "../community-posts.request.service";
 import { FetchPostCommand } from "./fetch-post.command";
 
 @CommandHandler(FetchPostCommand)
 export class FetchPostHandler implements ICommandHandler<FetchPostCommand> {
-    private readonly cache = new CacheCollection({
-        ttl: 600000 // 10 minutes,
-    })
+    private readonly cache = new CacheCollection<string, CommunityPost>({
+        ttl: 600000, // 10 minutes,
+    });
 
     constructor(
         private readonly requestService: YouTubeCommunityPostsRequestService,
     ) {}
-    
-    async execute({postId, forceRefetch}: FetchPostCommand): Promise<any> {
-        if (!forceRefetch && this.cache.has(postId)) return this.cache.get(postId);
-        return await this.requestService.fetchPostById(postId);
 
+    async execute({
+        postId,
+        forceRefetch,
+        includeChannel,
+    }: FetchPostCommand): Promise<any> {
+        if (!forceRefetch && this.cache.has(postId))
+            return this.cache.get(postId);
+        const result = await this.requestService.fetchSinglePost(
+            postId,
+            includeChannel,
+        );
+
+        // this is ugly, but it'll do.
+        this.cache.set(postId, includeChannel ? (result as {post: CommunityPost}).post : result as CommunityPost);
+
+        return result;
     }
 }

--- a/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
@@ -1,0 +1,21 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { CacheCollection } from "../../../../shared/util/cache-collection";
+import { YouTubeCommunityPostsRequestService } from "../community-posts.request.service";
+import { FetchPostCommand } from "./fetch-post.command";
+
+@CommandHandler(FetchPostCommand)
+export class FetchPostHandler implements ICommandHandler<FetchPostCommand> {
+    private readonly cache = new CacheCollection({
+        ttl: 600000 // 10 minutes,
+    })
+
+    constructor(
+        private readonly requestService: YouTubeCommunityPostsRequestService,
+    ) {}
+    
+    async execute({postId, forceRefetch}: FetchPostCommand): Promise<any> {
+        if (!forceRefetch && this.cache.has(postId)) return this.cache.get(postId);
+        return await this.requestService.fetchPostById(postId);
+
+    }
+}

--- a/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-post.handler.ts
@@ -27,7 +27,12 @@ export class FetchPostHandler implements ICommandHandler<FetchPostCommand> {
         );
 
         // this is ugly, but it'll do.
-        this.cache.set(postId, includeChannel ? (result as {post: CommunityPost}).post : result as CommunityPost);
+        this.cache.set(
+            postId,
+            includeChannel
+                ? (result as { post: CommunityPost }).post
+                : (result as CommunityPost),
+        );
 
         return result;
     }

--- a/src/modules/youtube/community-posts/commands/fetch-posts.command.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-posts.command.ts
@@ -3,6 +3,9 @@ import { Util } from "../../../../util";
 
 export interface FetchPostsCommandOptions {
     channelId: string;
+    /**
+     * Whether to include ChannelInfo in the result. Changes return type to `{posts: CommunityPost[], channel: ChannelInfo}`.
+     */
     includeChannelInfo?: boolean;
     /**
      * Whether to fetch all posts or only the most recent ones.

--- a/src/modules/youtube/community-posts/commands/fetch-posts.command.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-posts.command.ts
@@ -1,26 +1,25 @@
 import { ICommand } from "@nestjs/cqrs";
+import { Util } from "../../../../util";
 
-export interface FetchPostCommandOptions {
+export interface FetchPostsCommandOptions {
+    channelId: string;
     includeChannelInfo?: boolean;
-    force?: boolean;
-    postId?: string;
-    channelId?: string;
+    /**
+     * Whether to fetch all posts or only the most recent ones.
+     */
+    fetchAll?: boolean;
 }
 
-export class FetchPostsCommand implements ICommand {
-    public readonly includeChannelInfo?: boolean;
-    public readonly force?: boolean;
-    public readonly postId?: string;
-    public readonly channelId?: string;
+export class FetchPostsCommand implements ICommand, FetchPostsCommandOptions {
+    public readonly channelId: string;
+    public readonly includeChannelInfo = false;
+    public readonly fetchAll = false;
 
-    constructor(options: FetchPostCommandOptions = {}) {
-        if (options.channelId && options.postId)
-            throw new Error("Cannot specify both channelId and postId.");
-        if (!options.channelId && !options.postId)
-            throw new Error(
-                "Must specify either channelId or postId to fetch.",
+    constructor(options: FetchPostsCommandOptions) {
+        if (typeof options.channelId !== "string")
+            throw new TypeError(
+                `Expected options.channelId to be of type string, received ${typeof options.channelId}.`,
             );
-
-        Object.assign(this, options);
+        Util.assignIfDefined(this, options);
     }
 }

--- a/src/modules/youtube/community-posts/commands/fetch-posts.handler.ts
+++ b/src/modules/youtube/community-posts/commands/fetch-posts.handler.ts
@@ -1,59 +1,17 @@
 import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
-import { Repository } from "typeorm";
-import { CommunityPost as CommunityPostEntity } from "../model/community-post.entity";
 import { FetchPostsCommand } from "./fetch-posts.command";
-import {
-    ChannelInfo,
-    CommunityPost,
-    extractChannelInfo,
-    extractCommunityPosts,
-} from "yt-scraping-utilities";
-import { YouTubeService } from "../../youtube.service";
 import { Logger } from "@nestjs/common";
-import { InjectRepository } from "@nestjs/typeorm";
+import { YouTubeCommunityPostsRequestService } from "../community-posts.request.service";
 
 @CommandHandler(FetchPostsCommand)
 export class FetchPostsHandler implements ICommandHandler<FetchPostsCommand> {
     private readonly logger = new Logger(FetchPostsHandler.name);
 
     constructor(
-        private readonly youtubeService: YouTubeService,
-        @InjectRepository(CommunityPostEntity)
-        private readonly postRepo: Repository<CommunityPostEntity>,
+        private readonly requestService: YouTubeCommunityPostsRequestService,
     ) {}
 
-    async execute({
-        postId,
-        channelId,
-        includeChannelInfo,
-        force,
-    }: FetchPostsCommand): Promise<
-        CommunityPost[] | { posts: CommunityPost[]; channel: ChannelInfo }
-    > {
-        const data = (await this.youtubeService.fetchRaw(
-            postId
-                ? this.makePostLink(postId)
-                : this.makeCommunityLink(channelId),
-            {
-                maxRetries: 3,
-                requeuePriority: "high",
-            },
-            false,
-        )) as string;
-
-        const posts = extractCommunityPosts(data);
-        const channel = includeChannelInfo
-            ? extractChannelInfo(data)
-            : undefined;
-
-        return includeChannelInfo ? { posts, channel } : posts;
-    }
-
-    private makeCommunityLink(channelId: string) {
-        return `https://youtube.com/channel/${channelId}/community`;
-    }
-
-    private makePostLink(postId: string) {
-        return `https://youtube.com/post/${postId}`;
+    async execute(options: FetchPostsCommand): Promise<any> {
+        return this.requestService.fetchPosts(options);
     }
 }

--- a/src/modules/youtube/community-posts/commands/index.ts
+++ b/src/modules/youtube/community-posts/commands/index.ts
@@ -6,8 +6,7 @@ export const YouTubeCommunityPostCommandHandlers = [
     FetchPostHandler,
     FetchPostsHandler,
     SyncPostsHandler,
-]
-
+];
 
 export * from "./fetch-post.command";
 export * from "./fetch-posts.command";

--- a/src/modules/youtube/community-posts/commands/index.ts
+++ b/src/modules/youtube/community-posts/commands/index.ts
@@ -1,0 +1,14 @@
+import { FetchPostHandler } from "./fetch-post.handler";
+import { FetchPostsHandler } from "./fetch-posts.handler";
+import { SyncPostsHandler } from "./sync-posts.handler";
+
+export const YouTubeCommunityPostCommandHandlers = [
+    FetchPostHandler,
+    FetchPostsHandler,
+    SyncPostsHandler,
+]
+
+
+export * from "./fetch-post.command";
+export * from "./fetch-posts.command";
+export * from "./sync-posts.command";

--- a/src/modules/youtube/community-posts/commands/sync-posts.command.ts
+++ b/src/modules/youtube/community-posts/commands/sync-posts.command.ts
@@ -1,5 +1,6 @@
 import { ICommand } from "@nestjs/cqrs";
 import { CommunityPost } from "yt-scraping-utilities";
+import { Util } from "../../../../util";
 
 export interface SyncPostsCommandOptions {
     channelId?: string;
@@ -10,12 +11,14 @@ export interface SyncPostsCommandOptions {
  * Sync new posts to the database.
  * Prevents message spam when a new channel is added.
  */
-export class SyncPostsCommand implements ICommand {
+export class SyncPostsCommand implements ICommand, SyncPostsCommandOptions {
     public readonly channelId?: string;
     public readonly posts?: CommunityPost[];
 
     constructor(options: SyncPostsCommandOptions) {
-        this.channelId = options.channelId;
-        this.posts = options.posts;
+        if ((options.channelId && options.posts) || (!options.channelId && !options.posts)) 
+            throw new TypeError("Either channelId or posts need to be provided for syncing.");
+
+        Util.assignIfDefined(this, options);
     }
 }

--- a/src/modules/youtube/community-posts/commands/sync-posts.command.ts
+++ b/src/modules/youtube/community-posts/commands/sync-posts.command.ts
@@ -1,9 +1,16 @@
 import { ICommand } from "@nestjs/cqrs";
 import { CommunityPost } from "yt-scraping-utilities";
+import { RequireOnlyOne } from "yt-scraping-utilities/dist/util";
 import { Util } from "../../../../util";
 
 export interface SyncPostsCommandOptions {
+    /**
+     * Channel ID to fetch posts for.
+     */
     channelId?: string;
+    /**
+     * Posts to upsert into the database.
+     */
     posts?: CommunityPost[];
 }
 
@@ -15,9 +22,16 @@ export class SyncPostsCommand implements ICommand, SyncPostsCommandOptions {
     public readonly channelId?: string;
     public readonly posts?: CommunityPost[];
 
-    constructor(options: SyncPostsCommandOptions) {
-        if ((options.channelId && options.posts) || (!options.channelId && !options.posts)) 
-            throw new TypeError("Either channelId or posts need to be provided for syncing.");
+    constructor(
+        options: RequireOnlyOne<SyncPostsCommandOptions, "channelId" | "posts">,
+    ) {
+        if (
+            (options.channelId && options.posts) ||
+            (!options.channelId && !options.posts)
+        )
+            throw new TypeError(
+                "Either channelId or posts need to be provided for syncing.",
+            );
 
         Util.assignIfDefined(this, options);
     }

--- a/src/modules/youtube/community-posts/commands/sync-posts.handler.ts
+++ b/src/modules/youtube/community-posts/commands/sync-posts.handler.ts
@@ -12,6 +12,7 @@ import {
 } from "yt-scraping-utilities";
 import { findValuesByKeys } from "yt-scraping-utilities/dist/util";
 import { Logger } from "@nestjs/common";
+import { YouTubeCommunityPostsRequestService } from "../community-posts.request.service";
 
 @CommandHandler(SyncPostsCommand)
 export class SyncPostsHandler implements ICommandHandler<SyncPostsCommand> {
@@ -20,127 +21,16 @@ export class SyncPostsHandler implements ICommandHandler<SyncPostsCommand> {
     constructor(
         @InjectRepository(CommunityPostEntity)
         private readonly postRepo: Repository<CommunityPostEntity>,
-        private readonly youtubeService: YouTubeService,
+        private readonly requestService: YouTubeCommunityPostsRequestService,
     ) {}
 
-    private getPostsAndToken(
-        data: Record<string, any>,
-    ): [CommunityPost[], string | undefined] {
-        const posts: CommunityPost[] = findValuesByKeys(data, [
-            "sharedPostRenderer",
-            "backstagePostRenderer",
-        ]).map(extractPost);
-
-        const [continuationRenderer] = findValuesByKeys(data, [
-            "continuationItemRenderer",
-        ]);
-        const token =
-            continuationRenderer?.continuationEndpoint?.continuationCommand
-                ?.token;
-
-        return [posts, token];
-    }
-
-    async execute({ channelId, posts }: SyncPostsCommand) {
-        if (!channelId && typeof posts !== "object")
-            throw new TypeError(
-                "Either channelId or posts needs to be defined.",
-            );
-
-        if (channelId && !posts) {
-            this.logger.debug(`Fetching all posts for ${channelId}.`);
-            let clickTrackingParams: string;
-
-            const communityUrl = `https://youtube.com/channel/${channelId}/community`;
-            const headers: Record<string, string> = {
-                Referer: "https://youtube.com",
-            };
-
-            this.logger.debug(`Fetching community page for ${channelId}.`);
-            let ytInitialData, communityTab;
-            while (!communityTab) {
-                try {
-                    const data = (await this.youtubeService.fetchRaw(
-                        communityUrl,
-                        { requestOptions: { headers } },
-                        false,
-                    )) as string;
-                    ytInitialData = parseRawData({
-                        source: data,
-                        ytInitialData: true,
-                    }).ytInitialData;
-                    communityTab = findActiveTab(ytInitialData);
-                } catch (error) {
-                    this.logger.warn(`Failed fetching page for ${channelId}.`);
-                    if (error instanceof Error) {
-                        this.logger.error(error, error.stack);
-                    }
-                }
-            }
-
-            clickTrackingParams =
-                communityTab.tabRenderer.content.sectionListRenderer
-                    .trackingParams;
-            const visitorData =
-                ytInitialData.responseContext.webResponseContextExtensionData
-                    .ytConfigData.visitorData;
-
-            let [allPosts, continuationToken] =
-                this.getPostsAndToken(ytInitialData);
-
-            /*Object.assign(headers, {
-                "X-Youtube-Client-Name": "1",
-                "X-Youtube-Client-Version": YOUTUBE_CLIENT_VERSION,
-                "X-Youtube-Bootstrap-Logged-In": false,
-                "X-Goog-EOM-Visitor-Id": visitorData,
-                Origin: "https://youtube.com",
-                Host: "www.youtube.com",
-            });*/
-
-            while (continuationToken) {
-                /*const body = {
-                    context: {
-                        client: {
-                            clientName: "WEB",
-                            clientVersion: YOUTUBE_CLIENT_VERSION,
-                            originalUrl: "https://youtube.com",
-                            visitorData,
-                        },
-                        clickTracking: { clickTrackingParams },
-                    },
-                    continuation: continuationToken,
-                };
-
-                const data = (await this.youtubeService.fetchRaw(
-                    YOUTUBE_BROWSE_ENDPOINT,
-                    {
-                        requestOptions: { data: body, headers, method: "POST" },
-                    },
-                    false,
-                )) as Record<string, any>;*/
-                // TODO: type properly
-                const data = await this.youtubeService.doContinuationRequest<
-                    any,
-                    "",
-                    true
-                >({
-                    visitorData,
-                    token: continuationToken,
-                    clickTrackingParams,
-                });
-
-                const [newPosts, newToken] = this.getPostsAndToken(data);
-                allPosts.push(...newPosts);
-
-                headers.clickTrackingParams =
-                    data.onResponseReceivedEndpoints[0].clickTrackingParams;
-                continuationToken = newToken;
-            }
-
-            posts = allPosts;
-            this.logger.debug(
-                `Found a total of ${posts.length} posts for ${channelId}.`,
-            );
+    async execute({ channelId, posts = [] }: SyncPostsCommand = {}) {
+        if (channelId) {
+            posts = await this.requestService.fetchPosts({
+                channelId,
+                fetchAll: true,
+                includeChannel: false,
+            });
         }
 
         for (const post of posts) {

--- a/src/modules/youtube/community-posts/community-posts.request.service.ts
+++ b/src/modules/youtube/community-posts/community-posts.request.service.ts
@@ -1,28 +1,146 @@
 import { Injectable } from "@nestjs/common";
-import { extractCommunityPosts } from "yt-scraping-utilities";
+import {
+    ChannelInfo,
+    CommunityPost,
+    extractChannelInfo,
+    extractCommunityPosts,
+    extractPost,
+} from "yt-scraping-utilities";
+import {
+    findActiveTab,
+    findValuesByKeys,
+    parseRawData,
+} from "yt-scraping-utilities/dist/util";
 import { YouTubeService } from "../youtube.service";
+
+export interface FetchPostsOptions<C extends boolean> {
+    channelId: string;
+    fetchAll?: boolean;
+    includeChannel?: C;
+}
 
 @Injectable()
 export class YouTubeCommunityPostsRequestService {
-    constructor(
-        private readonly youtubeService: YouTubeService,
-    ) {}
+    constructor(private readonly youtubeService: YouTubeService) {}
 
-    public async fetchPostById(postId: string) {
-        const data = await this.youtubeService.fetchRaw(
+    public async fetchSinglePost<C extends boolean>(
+        postId: string,
+        includeChannel?: C,
+    ): Promise<
+        C extends true
+            ? { channel: ChannelInfo; post: CommunityPost }
+            : CommunityPost
+    >;
+    public async fetchSinglePost(
+        postId: string,
+        includeChannel?: boolean,
+    ): Promise<{ channel: ChannelInfo; post: CommunityPost } | CommunityPost> {
+        const data = (await this.youtubeService.fetchRaw(
             `https://youtube.com/post/${postId}`,
             {
                 maxRetries: 3,
                 requeuePriority: "high",
             },
             false,
-        ) as string;
+        )) as string;
 
-        const [post] = extractCommunityPosts(data);
+        const { ytInitialData } = parseRawData({
+            source: data,
+            ytInitialData: true,
+        });
+        const [post] = extractCommunityPosts(ytInitialData);
+
+        if (!includeChannel) return post;
+        else {
+            const channel = extractChannelInfo(ytInitialData);
+            return { channel, post };
+        }
     }
 
+    public async fetchPosts<C extends boolean>(
+        options: FetchPostsOptions<C>,
+    ): Promise<
+        C extends true
+            ? { channel: ChannelInfo; posts: CommunityPost[] }
+            : CommunityPost[]
+    >;
+    public async fetchPosts({
+        fetchAll,
+        includeChannel,
+        channelId,
+    }: FetchPostsOptions<any>): Promise<
+        CommunityPost[] | { channel: ChannelInfo; posts: CommunityPost[] }
+    > {
+        const initialPage = (await this.youtubeService.fetchRaw(
+            `https://youtube.com/channel/${channelId}/community`,
+            {
+                maxRetries: 3,
+                requeuePriority: "high",
+            },
+            false,
+        )) as string;
 
-    public async fetchPostsByChannelId(channelId: string) {
+        const { ytInitialData } = parseRawData({
+            source: initialPage,
+            ytInitialData: true,
+        });
 
+        const posts = extractCommunityPosts(ytInitialData);
+
+        const communityTab = findActiveTab(ytInitialData);
+
+        let { trackingParams } = communityTab.tabRenderer.content
+            .sectionListRenderer as { trackingParams: string };
+        const { visitorData } =
+            ytInitialData.responseContext.webResponseContextExtensionData
+                .ytConfigData;
+        let continuationToken = this.getContinuationToken(ytInitialData);
+
+        while (continuationToken && !fetchAll) {
+            const data = await this.youtubeService.doContinuationRequest<
+                any,
+                "",
+                true
+            >({
+                visitorData,
+                token: continuationToken,
+                clickTrackingParams: trackingParams,
+            });
+
+            posts.push(...this.getPosts(data));
+            continuationToken = this.getContinuationToken(data);
+        }
+
+        if (!includeChannel) return posts;
+        else {
+            const channel = extractChannelInfo(ytInitialData);
+            return { posts, channel };
+        }
+    }
+
+    /**
+     *
+     */
+    private getPosts(data: Record<string, any>): CommunityPost[] {
+        const posts: CommunityPost[] = findValuesByKeys(data, [
+            "sharedPostRenderer",
+            "backstagePostRenderer",
+        ]).map(extractPost);
+
+        return posts;
+    }
+
+    private getContinuationToken(
+        data: Record<string, any>,
+    ): string | undefined {
+        const [continuationRenderer] = findValuesByKeys(data, [
+            "continuationItemRenderer",
+        ]);
+
+        const token: string =
+            continuationRenderer?.continuationEndpoint?.continuationCommand
+                ?.token;
+
+        return token;
     }
 }

--- a/src/modules/youtube/community-posts/community-posts.request.service.ts
+++ b/src/modules/youtube/community-posts/community-posts.request.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@nestjs/common";
+import { extractCommunityPosts } from "yt-scraping-utilities";
+import { YouTubeService } from "../youtube.service";
+
+@Injectable()
+export class YouTubeCommunityPostsRequestService {
+    constructor(
+        private readonly youtubeService: YouTubeService,
+    ) {}
+
+    public async fetchPostById(postId: string) {
+        const data = await this.youtubeService.fetchRaw(
+            `https://youtube.com/post/${postId}`,
+            {
+                maxRetries: 3,
+                requeuePriority: "high",
+            },
+            false,
+        ) as string;
+
+        const [post] = extractCommunityPosts(data);
+    }
+
+
+    public async fetchPostsByChannelId(channelId: string) {
+
+    }
+}

--- a/src/modules/youtube/videos/commands/index.ts
+++ b/src/modules/youtube/videos/commands/index.ts
@@ -9,6 +9,5 @@ export { UnsubscribeCommand } from "./unsubscribe.command";
 export const YouTubeVideoCommandHandlers = [
     SubscribeHandler,
     UnsubscribeHandler,
-    SyncPostsHandler,
     FetchPostsHandler,
 ];

--- a/src/modules/youtube/youtube.module.ts
+++ b/src/modules/youtube/youtube.module.ts
@@ -3,6 +3,8 @@ import { CqrsModule } from "@nestjs/cqrs";
 import { ScheduleModule } from "@nestjs/schedule";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { YouTubeCommandHandlers } from "./commands";
+import { YouTubeCommunityPostCommandHandlers } from "./community-posts/commands";
+import { YouTubeCommunityPostsRequestService } from "./community-posts/community-posts.request.service";
 import { CommunityPost } from "./community-posts/model/community-post.entity";
 import { YouTubeCommunityPostsService } from "./community-posts/youtube-community-posts.service";
 import { YouTubeListenHandler } from "./events/listen.handler";
@@ -27,6 +29,8 @@ import { YouTubeService } from "./youtube.service";
         YouTubeService,
         YouTubeApiService,
         YouTubeCommunityPostsService,
+        YouTubeCommunityPostsRequestService,
+        ...YouTubeCommunityPostCommandHandlers,
         YouTubeEventSubService,
         YouTubeVideosService,
         ...YouTubeCommandHandlers,

--- a/src/util.ts
+++ b/src/util.ts
@@ -67,6 +67,18 @@ export namespace Util {
     export function last<T extends Array<any>>(array: T): LastArrayElement<T> {
         return array[array.length - 1];
     }
+
+    /**
+     * Assigns all enumerable properties from `source` to `target` if the property's value is not `undefined`.
+     * @param target the object to assign to.
+     * @param source the object to assign from.
+     */
+    export function assignIfDefined(target: object, source: object) {
+        for (const [key, value] of Object.entries(source)) {
+            if (typeof value == "undefined") continue;
+            target[key] = value;
+        }
+    }
 }
 
 export type Primitive = string | number | boolean;


### PR DESCRIPTION
Reworked Community Post commands to be slightly easier to use and expand upon.
This includes splitting the old command into respective single-post & multi-post commands,  and extracting the core fetching logic to a new service.